### PR TITLE
Fixes for farm summary due to upstream chia changes.

### DIFF
--- a/api/commands/chia_cli.py
+++ b/api/commands/chia_cli.py
@@ -60,7 +60,7 @@ def load_plots_farming():
         try:
             entries = (os.path.join(dir_path, file_name) for file_name in os.listdir(dir_path))
             entries = ((os.stat(path), path) for path in entries)
-            entries = ((stat[ST_CTIME], stat[ST_SIZE], path) for stat, path in entries if S_ISREG(stat[ST_MODE]))
+            entries = ((stat[ST_MTIME], stat[ST_SIZE], path) for stat, path in entries if S_ISREG(stat[ST_MODE]))
             all_entries.extend(entries)
         except:
             app.logger.info("Failed to list files at {0}".format(dir_path))

--- a/api/models/chia.py
+++ b/api/models/chia.py
@@ -14,16 +14,24 @@ class FarmSummary:
 
     def __init__(self, cli_stdout=None, farm_plots=None):
         if cli_stdout:
+            next_line_local_harvester = False
+            self.plots_size = None
             for line in cli_stdout:
-                if "status" in line: 
+                if next_line_local_harvester:
+                    self.plot_count = line.strip().split(' ')[0]
+                    self.plots_size = line.strip().split(':')[1].strip()
+                    next_line_local_harvester = False
+                elif "status" in line: 
                     self.calc_status(line.split(':')[1].strip())
                 elif "Total chia farmed" in line:
                     self.total_chia = line.split(':')[1].strip()
                 elif "Total flax farmed" in line:
                     self.total_chia = line.split(':')[1].strip()
-                elif "Plot count" in line:
+                elif "Plot count:" in line:
                     self.plot_count = line.split(':')[1].strip()
-                elif "Total size of plots" in line:
+                elif "Harvester 127.0.0.1:" in line:
+                    next_line_local_harvester = True
+                elif not self.plots_size and "Total size of plots" in line:
                     self.plots_size = line.split(':')[1].strip()
                 elif "Estimated network space" in line:
                     self.calc_netspace_size(line.split(':')[1].strip())

--- a/common/utils/converters.py
+++ b/common/utils/converters.py
@@ -28,8 +28,8 @@ def str_to_gibs(str):
         elif unit.lower().strip().endswith('eib'):
             return float(val) * 1024 * 1024 * 1024
     except:
-        logging.info("Failed to convert to GiB: {0}".format(str))
-        logging.info(traceback.format_exc())
+        print("Failed to convert to GiB: {0}".format(str))
+        print(traceback.format_exc())
         return None
 
 


### PR DESCRIPTION
Upstream devs introduced new output for the `chia farm summary` command on a fullnode/farmer:

```
root@aragorn:/chia-blockchain# chia farm summary
Farming status: Farming
Total chia farmed: 0.0
User transaction fees: 0.0
Block rewards: 0.0
Last height farmed: 0
Harvester 127.0.0.1:42752:
   333 plots of size: 32.960 TiB
Harvester 192.168.1.100:52028:
   20 plots of size: 1.979 TiB
Plot count for all harvesters: 353
Total size of plots: 34.940 TiB
Estimated network space: 29.850 EiB
Expected time to win: 6 months and 1 week
Note: log into your key using 'chia wallet show' to see rewards for each key
```

Had to change WebUI display to accomodate.