### PR TITLE
Remove double spaces from localization files

### DIFF
--- a/api/translations/de_DE/LC_MESSAGES/messages.po
+++ b/api/translations/de_DE/LC_MESSAGES/messages.po
@@ -35,14 +35,14 @@ msgstr ""
 #: commands/pools_cli.py:195
 #, python-format
 msgid ""
-"Successfully joined %(pool_url)s pool by creating Chia NFT.  Please wait "
+"Successfully joined %(pool_url)s pool by creating Chia NFT. Please wait "
 "a few minutes or more to complete. DO NOT immediately re-submit your "
 "request. Be patient! View the log for details."
 msgstr ""
 
 #: commands/pools_cli.py:224
 msgid ""
-"Successfully created a NFT for self-pooling.  Please wait a few minutes "
+"Successfully created a NFT for self-pooling. Please wait a few minutes "
 "or more to complete. DO NOT immediately re-submit your request. Be "
 "patient! View the log for details."
 msgstr ""

--- a/api/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/api/translations/fr_FR/LC_MESSAGES/messages.po
@@ -42,7 +42,7 @@ msgstr ""
 #: commands/pools_cli.py:195
 #, python-format
 msgid ""
-"Successfully joined %(pool_url)s pool by creating Chia NFT.  Please wait "
+"Successfully joined %(pool_url)s pool by creating Chia NFT. Please wait "
 "a few minutes or more to complete. DO NOT immediately re-submit your "
 "request. Be patient! View the log for details."
 msgstr ""
@@ -53,7 +53,7 @@ msgstr ""
 
 #: commands/pools_cli.py:224
 msgid ""
-"Successfully created a NFT for self-pooling.  Please wait a few minutes "
+"Successfully created a NFT for self-pooling. Please wait a few minutes "
 "or more to complete. DO NOT immediately re-submit your request. Be "
 "patient! View the log for details."
 msgstr ""

--- a/api/translations/it_IT/LC_MESSAGES/messages.po
+++ b/api/translations/it_IT/LC_MESSAGES/messages.po
@@ -36,14 +36,14 @@ msgstr ""
 #: commands/pools_cli.py:195
 #, python-format
 msgid ""
-"Successfully joined %(pool_url)s pool by creating Chia NFT.  Please wait "
+"Successfully joined %(pool_url)s pool by creating Chia NFT. Please wait "
 "a few minutes or more to complete. DO NOT immediately re-submit your "
 "request. Be patient! View the log for details."
 msgstr ""
 
 #: commands/pools_cli.py:224
 msgid ""
-"Successfully created a NFT for self-pooling.  Please wait a few minutes "
+"Successfully created a NFT for self-pooling. Please wait a few minutes "
 "or more to complete. DO NOT immediately re-submit your request. Be "
 "patient! View the log for details."
 msgstr ""

--- a/api/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/api/translations/pt_PT/LC_MESSAGES/messages.po
@@ -41,7 +41,7 @@ msgstr ""
 #: commands/pools_cli.py:195
 #, python-format
 msgid ""
-"Successfully joined %(pool_url)s pool by creating Chia NFT.  Please wait "
+"Successfully joined %(pool_url)s pool by creating Chia NFT. Please wait "
 "a few minutes or more to complete. DO NOT immediately re-submit your "
 "request. Be patient! View the log for details."
 msgstr ""
@@ -52,7 +52,7 @@ msgstr ""
 
 #: commands/pools_cli.py:224
 msgid ""
-"Successfully created a NFT for self-pooling.  Please wait a few minutes "
+"Successfully created a NFT for self-pooling. Please wait a few minutes "
 "or more to complete. DO NOT immediately re-submit your request. Be "
 "patient! View the log for details."
 msgstr ""

--- a/api/translations/zh/LC_MESSAGES/messages.po
+++ b/api/translations/zh/LC_MESSAGES/messages.po
@@ -36,14 +36,14 @@ msgstr ""
 #: commands/pools_cli.py:195
 #, python-format
 msgid ""
-"Successfully joined %(pool_url)s pool by creating Chia NFT.  Please wait "
+"Successfully joined %(pool_url)s pool by creating Chia NFT. Please wait "
 "a few minutes or more to complete. DO NOT immediately re-submit your "
 "request. Be patient! View the log for details."
 msgstr ""
 
 #: commands/pools_cli.py:224
 msgid ""
-"Successfully created a NFT for self-pooling.  Please wait a few minutes "
+"Successfully created a NFT for self-pooling. Please wait a few minutes "
 "or more to complete. DO NOT immediately re-submit your request. Be "
 "patient! View the log for details."
 msgstr ""

--- a/web/translations/de_DE/LC_MESSAGES/messages.po
+++ b/web/translations/de_DE/LC_MESSAGES/messages.po
@@ -44,7 +44,7 @@ msgstr ""
 
 #: routes.py:279
 msgid ""
-"Saved mapping settings.  Please allow 10 minutes to generate location "
+"Saved mapping settings. Please allow 10 minutes to generate location "
 "information for the map."
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 
 #: actions/chia.py:44
 msgid ""
-"Relax and grab a coffee. Status is being gathered from active workers.  "
+"Relax and grab a coffee. Status is being gathered from active workers. "
 "Please allow 15 minutes..."
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 
 #: templates/wallet.html:172
 msgid ""
-"No wallet status received.  Perhaps just starting?  Please allow at least"
+"No wallet status received. Perhaps just starting? Please allow at least"
 " 10 minutes to update."
 msgstr ""
 
@@ -916,7 +916,7 @@ msgstr ""
 
 #: templates/worker_launch.html:266
 msgid ""
-"Missing worker hostname.  Please provide a short name to identify your "
+"Missing worker hostname. Please provide a short name to identify your "
 "worker."
 msgstr ""
 
@@ -943,12 +943,12 @@ msgid "Please provide a container path."
 msgstr ""
 
 #: templates/worker_launch.html:332
-msgid "Neither Harvester or Plottter mode selected.  Please choose one or both."
+msgid "Neither Harvester or Plottter mode selected. Please choose one or both."
 msgstr ""
 
 #: templates/worker_launch.html:338
 msgid ""
-"Missing worker IP address.  Please provide the IP the conntroller will "
+"Missing worker IP address. Please provide the IP the conntroller will "
 "connect to for commands."
 msgstr ""
 
@@ -1189,7 +1189,7 @@ msgstr ""
 
 #: templates/plotting/jobs.html:49
 msgid ""
-"This action will stop Plotman from launching new plotting jobs.  Running "
+"This action will stop Plotman from launching new plotting jobs. Running "
 "jobs will run to completion. Continue?"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 #: templates/plotting/jobs.html:67 templates/plotting/workers.html:67
 msgid ""
 "This worker is not currently online and responding to pings from the "
-"controller.  Please check the Workers page and bring the system back "
+"controller. Please check the Workers page and bring the system back "
 "online."
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid ""
 "This worker is not currently configured for Plotman "
 "%(wiki_link_open)sarchiving%(wiki_link_open)s to enable local or remote "
-"transfer of completed plots.  Please visit the Settings | Plotting page "
+"transfer of completed plots. Please visit the Settings | Plotting page "
 "to configure this worker."
 msgstr ""
 
@@ -1278,7 +1278,7 @@ msgid "Archiving"
 msgstr ""
 
 #: templates/plotting/workers.html:119
-msgid "Archiving is disabled.  See Settings | Plotting page."
+msgid "Archiving is disabled. See Settings | Plotting page."
 msgstr ""
 
 #: templates/settings/alerts.html:57 templates/settings/farming.html:58
@@ -1339,7 +1339,7 @@ msgstr ""
 
 #: templates/settings/pools.html:172
 msgid ""
-"No wallets found yet.  Perhaps this is a brand-new installation? If so, "
+"No wallets found yet. Perhaps this is a brand-new installation? If so, "
 "please wait for complete start-up."
 msgstr ""
 

--- a/web/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/web/translations/fr_FR/LC_MESSAGES/messages.po
@@ -44,7 +44,7 @@ msgstr "Adresses de portefeuille froid enregistrées."
 
 #: routes.py:279
 msgid ""
-"Saved mapping settings.  Please allow 10 minutes to generate location "
+"Saved mapping settings. Please allow 10 minutes to generate location "
 "information for the map."
 msgstr ""
 "Paramètres de cartographie enregistrés. Veuillez patienter 10 minutes "
@@ -98,7 +98,7 @@ msgstr "Type de journal non pris en charge"
 
 #: actions/chia.py:44
 msgid ""
-"Relax and grab a coffee. Status is being gathered from active workers.  "
+"Relax and grab a coffee. Status is being gathered from active workers. "
 "Please allow 15 minutes..."
 msgstr ""
 
@@ -844,7 +844,7 @@ msgstr "Détails du portefeuille"
 
 #: templates/wallet.html:172
 msgid ""
-"No wallet status received.  Perhaps just starting?  Please allow at least"
+"No wallet status received. Perhaps just starting? Please allow at least"
 " 10 minutes to update."
 msgstr ""
 "Aucun statut de portefeuille reçu. Peut-être que vous venez juste de "
@@ -964,7 +964,7 @@ msgstr "Blockchain inconnue de la sélection:"
 
 #: templates/worker_launch.html:266
 msgid ""
-"Missing worker hostname.  Please provide a short name to identify your "
+"Missing worker hostname. Please provide a short name to identify your "
 "worker."
 msgstr ""
 "Nom d'hôte du worker de calcul manquant. Veuillez fournir un nom court "
@@ -995,14 +995,14 @@ msgid "Please provide a container path."
 msgstr "Veuillez fournir un chemin de conteneur."
 
 #: templates/worker_launch.html:332
-msgid "Neither Harvester or Plottter mode selected.  Please choose one or both."
+msgid "Neither Harvester or Plottter mode selected. Please choose one or both."
 msgstr ""
 "Aucun mode Harvester ou Plotter n'est sélectionné. Veuillez en choisir un"
 " ou les deux."
 
 #: templates/worker_launch.html:338
 msgid ""
-"Missing worker IP address.  Please provide the IP the conntroller will "
+"Missing worker IP address. Please provide the IP the conntroller will "
 "connect to for commands."
 msgstr ""
 "Adresse IP du worker manquante. Veuillez fournir l'adresse IP que le "
@@ -1268,7 +1268,7 @@ msgstr "Arrête Plotting"
 
 #: templates/plotting/jobs.html:49
 msgid ""
-"This action will stop Plotman from launching new plotting jobs.  Running "
+"This action will stop Plotman from launching new plotting jobs. Running "
 "jobs will run to completion. Continue?"
 msgstr ""
 "This action will stop Plotman from launching new plotting jobs. Running "
@@ -1286,7 +1286,7 @@ msgstr "Worker est hors ligne."
 #: templates/plotting/jobs.html:67 templates/plotting/workers.html:67
 msgid ""
 "This worker is not currently online and responding to pings from the "
-"controller.  Please check the Workers page and bring the system back "
+"controller. Please check the Workers page and bring the system back "
 "online."
 msgstr ""
 "Ce worker n'est pas en ligne actuellement et répond aux pings du "
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid ""
 "This worker is not currently configured for Plotman "
 "%(wiki_link_open)sarchiving%(wiki_link_open)s to enable local or remote "
-"transfer of completed plots.  Please visit the Settings | Plotting page "
+"transfer of completed plots. Please visit the Settings | Plotting page "
 "to configure this worker."
 msgstr ""
 "Ce worker n'est actuellement pas configuré pour "
@@ -1371,7 +1371,7 @@ msgid "Archiving"
 msgstr "Archivage"
 
 #: templates/plotting/workers.html:119
-msgid "Archiving is disabled.  See Settings | Plotting page."
+msgid "Archiving is disabled. See Settings | Plotting page."
 msgstr "L'archivage est désactivé. Voir page Paramètres | Traçage."
 
 #: templates/settings/alerts.html:57 templates/settings/farming.html:58
@@ -1438,7 +1438,7 @@ msgstr "Afficher le journal"
 
 #: templates/settings/pools.html:172
 msgid ""
-"No wallets found yet.  Perhaps this is a brand-new installation? If so, "
+"No wallets found yet. Perhaps this is a brand-new installation? If so, "
 "please wait for complete start-up."
 msgstr ""
 "Aucun portefeuille trouvé pour le moment. Peut-être s'agit-il d'une toute"

--- a/web/translations/it_IT/LC_MESSAGES/messages.po
+++ b/web/translations/it_IT/LC_MESSAGES/messages.po
@@ -44,7 +44,7 @@ msgstr ""
 
 #: routes.py:279
 msgid ""
-"Saved mapping settings.  Please allow 10 minutes to generate location "
+"Saved mapping settings. Please allow 10 minutes to generate location "
 "information for the map."
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 
 #: actions/chia.py:44
 msgid ""
-"Relax and grab a coffee. Status is being gathered from active workers.  "
+"Relax and grab a coffee. Status is being gathered from active workers. "
 "Please allow 15 minutes..."
 msgstr ""
 
@@ -795,7 +795,7 @@ msgstr ""
 
 #: templates/wallet.html:172
 msgid ""
-"No wallet status received.  Perhaps just starting?  Please allow at least"
+"No wallet status received. Perhaps just starting? Please allow at least"
 " 10 minutes to update."
 msgstr ""
 
@@ -913,7 +913,7 @@ msgstr ""
 
 #: templates/worker_launch.html:266
 msgid ""
-"Missing worker hostname.  Please provide a short name to identify your "
+"Missing worker hostname. Please provide a short name to identify your "
 "worker."
 msgstr ""
 
@@ -940,12 +940,12 @@ msgid "Please provide a container path."
 msgstr ""
 
 #: templates/worker_launch.html:332
-msgid "Neither Harvester or Plottter mode selected.  Please choose one or both."
+msgid "Neither Harvester or Plottter mode selected. Please choose one or both."
 msgstr ""
 
 #: templates/worker_launch.html:338
 msgid ""
-"Missing worker IP address.  Please provide the IP the conntroller will "
+"Missing worker IP address. Please provide the IP the conntroller will "
 "connect to for commands."
 msgstr ""
 
@@ -1184,7 +1184,7 @@ msgstr ""
 
 #: templates/plotting/jobs.html:49
 msgid ""
-"This action will stop Plotman from launching new plotting jobs.  Running "
+"This action will stop Plotman from launching new plotting jobs. Running "
 "jobs will run to completion. Continue?"
 msgstr ""
 
@@ -1200,7 +1200,7 @@ msgstr ""
 #: templates/plotting/jobs.html:67 templates/plotting/workers.html:67
 msgid ""
 "This worker is not currently online and responding to pings from the "
-"controller.  Please check the Workers page and bring the system back "
+"controller. Please check the Workers page and bring the system back "
 "online."
 msgstr ""
 
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid ""
 "This worker is not currently configured for Plotman "
 "%(wiki_link_open)sarchiving%(wiki_link_open)s to enable local or remote "
-"transfer of completed plots.  Please visit the Settings | Plotting page "
+"transfer of completed plots. Please visit the Settings | Plotting page "
 "to configure this worker."
 msgstr ""
 
@@ -1273,7 +1273,7 @@ msgid "Archiving"
 msgstr ""
 
 #: templates/plotting/workers.html:119
-msgid "Archiving is disabled.  See Settings | Plotting page."
+msgid "Archiving is disabled. See Settings | Plotting page."
 msgstr ""
 
 #: templates/settings/alerts.html:57 templates/settings/farming.html:58
@@ -1334,7 +1334,7 @@ msgstr ""
 
 #: templates/settings/pools.html:172
 msgid ""
-"No wallets found yet.  Perhaps this is a brand-new installation? If so, "
+"No wallets found yet. Perhaps this is a brand-new installation? If so, "
 "please wait for complete start-up."
 msgstr ""
 

--- a/web/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/web/translations/pt_PT/LC_MESSAGES/messages.po
@@ -44,7 +44,7 @@ msgstr "O endereço da Cold Wallet foi gravado."
 
 #: routes.py:279
 msgid ""
-"Saved mapping settings.  Please allow 10 minutes to generate location "
+"Saved mapping settings. Please allow 10 minutes to generate location "
 "information for the map."
 msgstr ""
 "A definições do mapa foram gravadas. Por favor aguarde 10 minutos para "
@@ -98,7 +98,7 @@ msgstr "Tipo de log não suportado"
 
 #: actions/chia.py:44
 msgid ""
-"Relax and grab a coffee. Status is being gathered from active workers.  "
+"Relax and grab a coffee. Status is being gathered from active workers. "
 "Please allow 15 minutes..."
 msgstr ""
 
@@ -853,7 +853,7 @@ msgstr "Detalhes da Wallet"
 
 #: templates/wallet.html:172
 msgid ""
-"No wallet status received.  Perhaps just starting?  Please allow at least"
+"No wallet status received. Perhaps just starting? Please allow at least"
 " 10 minutes to update."
 msgstr ""
 "O estado da Wallet ainda não foi recebido. Acabaste de arrancar o "
@@ -975,7 +975,7 @@ msgstr "Unknown blockchain fork of selected:"
 
 #: templates/worker_launch.html:266
 msgid ""
-"Missing worker hostname.  Please provide a short name to identify your "
+"Missing worker hostname. Please provide a short name to identify your "
 "worker."
 msgstr ""
 "Falta o hostname do Worker. Por favor indique um nome cursto para "
@@ -1006,14 +1006,14 @@ msgid "Please provide a container path."
 msgstr "Por favor indique um container path."
 
 #: templates/worker_launch.html:332
-msgid "Neither Harvester or Plottter mode selected.  Please choose one or both."
+msgid "Neither Harvester or Plottter mode selected. Please choose one or both."
 msgstr ""
 "Não foi seleccionado o modo Harvester nem o modo Plottter. Por favor "
 "escolha um ou ambos."
 
 #: templates/worker_launch.html:338
 msgid ""
-"Missing worker IP address.  Please provide the IP the conntroller will "
+"Missing worker IP address. Please provide the IP the conntroller will "
 "connect to for commands."
 msgstr ""
 "Falta o endereço IP do Worker. Por favor indique o endereço IP que o "
@@ -1247,7 +1247,7 @@ msgid ""
 msgstr ""
 "Esta acção irá terminar os Plots seleccionados, estejam estes a correr ou"
 " parados, e apagar todos os ficheiros temporários. Se o Plotman ainda "
-"está a correr, outro  Plot será iniciado automaticamente, por isso "
+"está a correr, outro Plot será iniciado automaticamente, por isso "
 "primeiro pare o Plotman a partir do canto superior direito. Continuar?"
 
 #: templates/plotting/jobs.html:17 templates/plotting/jobs.html:193
@@ -1278,7 +1278,7 @@ msgstr "Parar Plotting"
 
 #: templates/plotting/jobs.html:49
 msgid ""
-"This action will stop Plotman from launching new plotting jobs.  Running "
+"This action will stop Plotman from launching new plotting jobs. Running "
 "jobs will run to completion. Continue?"
 msgstr ""
 "Esta acção irá impedir que o Plotman lance novos plotting jobs. Os jobs "
@@ -1296,7 +1296,7 @@ msgstr "Worker offline"
 #: templates/plotting/jobs.html:67 templates/plotting/workers.html:67
 msgid ""
 "This worker is not currently online and responding to pings from the "
-"controller.  Please check the Workers page and bring the system back "
+"controller. Please check the Workers page and bring the system back "
 "online."
 msgstr ""
 "Este Worker não está actualmente online e a responder a pings do "
@@ -1369,10 +1369,10 @@ msgstr ""
 msgid ""
 "This worker is not currently configured for Plotman "
 "%(wiki_link_open)sarchiving%(wiki_link_open)s to enable local or remote "
-"transfer of completed plots.  Please visit the Settings | Plotting page "
+"transfer of completed plots. Please visit the Settings | Plotting page "
 "to configure this worker."
 msgstr ""
-"Este  Worker não está actualmente configurado para o Plotman "
+"Este Worker não está actualmente configurado para o Plotman "
 "%(wiki_link_open)sarchiving%(wiki_link_open)s para activar transferencias"
 " locais ou remotas de Plots que tenham terminado para. Por favor veja a "
 "página Definições | Plotting para configurar este Worker."
@@ -1382,7 +1382,7 @@ msgid "Archiving"
 msgstr "Arquivar"
 
 #: templates/plotting/workers.html:119
-msgid "Archiving is disabled.  See Settings | Plotting page."
+msgid "Archiving is disabled. See Settings | Plotting page."
 msgstr "Arquivar: Desactivado. Veja a página Definições | Plotting."
 
 #: templates/settings/alerts.html:57 templates/settings/farming.html:58
@@ -1451,7 +1451,7 @@ msgstr "Ver log"
 
 #: templates/settings/pools.html:172
 msgid ""
-"No wallets found yet.  Perhaps this is a brand-new installation? If so, "
+"No wallets found yet. Perhaps this is a brand-new installation? If so, "
 "please wait for complete start-up."
 msgstr ""
 "Ainda não foi encontrado nenhuma Wallet. Talvez tenha acabado de instalar"

--- a/web/translations/zh/LC_MESSAGES/messages.po
+++ b/web/translations/zh/LC_MESSAGES/messages.po
@@ -44,7 +44,7 @@ msgstr ""
 
 #: routes.py:279
 msgid ""
-"Saved mapping settings.  Please allow 10 minutes to generate location "
+"Saved mapping settings. Please allow 10 minutes to generate location "
 "information for the map."
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 
 #: actions/chia.py:44
 msgid ""
-"Relax and grab a coffee. Status is being gathered from active workers.  "
+"Relax and grab a coffee. Status is being gathered from active workers. "
 "Please allow 15 minutes..."
 msgstr ""
 
@@ -795,7 +795,7 @@ msgstr ""
 
 #: templates/wallet.html:172
 msgid ""
-"No wallet status received.  Perhaps just starting?  Please allow at least"
+"No wallet status received. Perhaps just starting? Please allow at least"
 " 10 minutes to update."
 msgstr ""
 
@@ -913,7 +913,7 @@ msgstr ""
 
 #: templates/worker_launch.html:266
 msgid ""
-"Missing worker hostname.  Please provide a short name to identify your "
+"Missing worker hostname. Please provide a short name to identify your "
 "worker."
 msgstr ""
 
@@ -940,12 +940,12 @@ msgid "Please provide a container path."
 msgstr ""
 
 #: templates/worker_launch.html:332
-msgid "Neither Harvester or Plottter mode selected.  Please choose one or both."
+msgid "Neither Harvester or Plottter mode selected. Please choose one or both."
 msgstr ""
 
 #: templates/worker_launch.html:338
 msgid ""
-"Missing worker IP address.  Please provide the IP the conntroller will "
+"Missing worker IP address. Please provide the IP the conntroller will "
 "connect to for commands."
 msgstr ""
 
@@ -1184,7 +1184,7 @@ msgstr ""
 
 #: templates/plotting/jobs.html:49
 msgid ""
-"This action will stop Plotman from launching new plotting jobs.  Running "
+"This action will stop Plotman from launching new plotting jobs. Running "
 "jobs will run to completion. Continue?"
 msgstr ""
 
@@ -1200,7 +1200,7 @@ msgstr ""
 #: templates/plotting/jobs.html:67 templates/plotting/workers.html:67
 msgid ""
 "This worker is not currently online and responding to pings from the "
-"controller.  Please check the Workers page and bring the system back "
+"controller. Please check the Workers page and bring the system back "
 "online."
 msgstr ""
 
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid ""
 "This worker is not currently configured for Plotman "
 "%(wiki_link_open)sarchiving%(wiki_link_open)s to enable local or remote "
-"transfer of completed plots.  Please visit the Settings | Plotting page "
+"transfer of completed plots. Please visit the Settings | Plotting page "
 "to configure this worker."
 msgstr ""
 
@@ -1273,7 +1273,7 @@ msgid "Archiving"
 msgstr ""
 
 #: templates/plotting/workers.html:119
-msgid "Archiving is disabled.  See Settings | Plotting page."
+msgid "Archiving is disabled. See Settings | Plotting page."
 msgstr ""
 
 #: templates/settings/alerts.html:57 templates/settings/farming.html:58
@@ -1334,7 +1334,7 @@ msgstr ""
 
 #: templates/settings/pools.html:172
 msgid ""
-"No wallets found yet.  Perhaps this is a brand-new installation? If so, "
+"No wallets found yet. Perhaps this is a brand-new installation? If so, "
 "please wait for complete start-up."
 msgstr ""
 


### PR DESCRIPTION
I noticed that a lot of strings have double spaces.
If that doesn't cause too much trouble to the translation process and doesn't hurt anyone's work, I would suggest updating all the `messages.po` files removing them.

I already went through all the `messages.po` files of all the languages for both the `api` and `web` parts.
If everything looks good the PR should be already ready to be merged.