### PR TITLE
Fix a typo in 'web/templates/worker_launch.html'

### DIFF
--- a/web/templates/worker_launch.html
+++ b/web/templates/worker_launch.html
@@ -358,7 +358,7 @@
                         cmd += '            - worker_address=' + document.getElementById("ip_addr").value + line_end;
                     }
                     else if (i == 0) {
-                        errors.push("{{_('Missing worker IP address.  Please provide the IP the conntroller will connect to for commands.')}}");
+                        errors.push("{{_('Missing worker IP address.  Please provide the IP the controller will connect to for commands.')}}");
                     }
                     var worker_port = lookup_worker_port(blockchain);
                     cmd += '            - worker_api_port=' + worker_port + line_end;

--- a/web/translations/de_DE/LC_MESSAGES/messages.po
+++ b/web/translations/de_DE/LC_MESSAGES/messages.po
@@ -948,7 +948,7 @@ msgstr ""
 
 #: templates/worker_launch.html:338
 msgid ""
-"Missing worker IP address.  Please provide the IP the conntroller will "
+"Missing worker IP address.  Please provide the IP the controller will "
 "connect to for commands."
 msgstr ""
 

--- a/web/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/web/translations/fr_FR/LC_MESSAGES/messages.po
@@ -1002,7 +1002,7 @@ msgstr ""
 
 #: templates/worker_launch.html:338
 msgid ""
-"Missing worker IP address.  Please provide the IP the conntroller will "
+"Missing worker IP address.  Please provide the IP the controller will "
 "connect to for commands."
 msgstr ""
 "Adresse IP du worker manquante. Veuillez fournir l'adresse IP que le "

--- a/web/translations/it_IT/LC_MESSAGES/messages.po
+++ b/web/translations/it_IT/LC_MESSAGES/messages.po
@@ -945,7 +945,7 @@ msgstr ""
 
 #: templates/worker_launch.html:338
 msgid ""
-"Missing worker IP address.  Please provide the IP the conntroller will "
+"Missing worker IP address.  Please provide the IP the controller will "
 "connect to for commands."
 msgstr ""
 

--- a/web/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/web/translations/pt_PT/LC_MESSAGES/messages.po
@@ -1013,7 +1013,7 @@ msgstr ""
 
 #: templates/worker_launch.html:338
 msgid ""
-"Missing worker IP address.  Please provide the IP the conntroller will "
+"Missing worker IP address.  Please provide the IP the controller will "
 "connect to for commands."
 msgstr ""
 "Falta o endereço IP do Worker. Por favor indique o endereço IP que o "

--- a/web/translations/zh/LC_MESSAGES/messages.po
+++ b/web/translations/zh/LC_MESSAGES/messages.po
@@ -945,7 +945,7 @@ msgstr ""
 
 #: templates/worker_launch.html:338
 msgid ""
-"Missing worker IP address.  Please provide the IP the conntroller will "
+"Missing worker IP address.  Please provide the IP the controller will "
 "connect to for commands."
 msgstr ""
 


### PR DESCRIPTION
## Description
I found a typo in `web/templates/worker_launch.html` and consequently in all the web `messages.po` files.
The wrongly spelled word is **_conntroller_** and can be found in `web/templates/worker_launch.html` at line 361.



## What to do
If it is sufficiently relevant to merge this fix, please check if there is something else to change before merging.
