### PR TITLE
Fix broken help button's link in Connections page

### DIFF
--- a/web/templates/connections.html
+++ b/web/templates/connections.html
@@ -58,7 +58,7 @@
         <div class="position-absolute top-0 end-0" style="z-index: 2000; margin-top: -20px; margin-right: -8px;">
             <a href="#" title="{{_('Settings')}}" data-bs-toggle="modal" data-bs-target="#settingsModal" target="_blank"><i class="fs-4 bi-gear"></i></a>
             &nbsp;
-            <a href="https://github.com/guydavis/machinaris/wiki/Connections target="_blank"><i class="fs-4 bi-question-circle"></i></a>
+            <a href="https://github.com/guydavis/machinaris/wiki/Connections" target="_blank"><i class="fs-4 bi-question-circle"></i></a>
         </div>
     </div>
 


### PR DESCRIPTION
Due to a missing double-quote, the link of the top-right help button in the Connections page was broken.
