### PR TITLE
Fix the translation of 'Download' for the it_it language

### DIFF
--- a/web/translations/it_IT/LC_MESSAGES/messages.po
+++ b/web/translations/it_IT/LC_MESSAGES/messages.po
@@ -1467,7 +1467,7 @@ msgstr ""
 #: templates/settings/alerts.html:57 templates/settings/farming.html:58
 #: templates/settings/plotting.html:58 templates/settings/tools.html:57
 msgid "Download"
-msgstr "Scaricamento"
+msgstr "Scarica"
 
 #: templates/settings/pools.html:32
 msgid "Confirm Pool Change"


### PR DESCRIPTION
The previous translation assumed that the word "Download" meant that the download was in progress, not the Call To Action to start the Download.

<!-- Please develop and target PRs against the integration branch, not main. -->