### PR TITLE
Fix the it_IT translation for "Archiving"

### DIFF
--- a/web/translations/it_IT/LC_MESSAGES/messages.po
+++ b/web/translations/it_IT/LC_MESSAGES/messages.po
@@ -1456,7 +1456,7 @@ msgstr ""
 
 #: templates/plotting/workers.html:103
 msgid "Archiving"
-msgstr "Archiviazione in corso"
+msgstr "Archiviazione"
 
 #: templates/plotting/workers.html:119
 msgid "Archiving is disabled.  See Settings | Plotting page."


### PR DESCRIPTION
The previous translations assumed that the meaning of "Archiving" was that the archiving was in progress. Instead, it preceded the archiving status.

