### PR TITLE
Gigahorse dropped arm64 support.

### DIFF
--- a/.github/workflows/main-chia.yaml
+++ b/.github/workflows/main-chia.yaml
@@ -84,7 +84,7 @@ jobs:
         with:
           file: docker/dockerfile
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           provenance: false
           push: true
           build-args: |


### PR DESCRIPTION
<!-- Please develop and target PRs against the integration branch, not main. -->