### PR TITLE
Workaround for CNI's odd branch naming practices.

### DIFF
--- a/.github/workflows/develop-chia.yaml
+++ b/.github/workflows/develop-chia.yaml
@@ -44,7 +44,7 @@ jobs:
             "UBUNTU_VER=jammy"
             "MACHINARIS_STREAM=develop"
             "CHIADOG_BRANCH=dev"
-            "CHIA_BRANCH=release/2.1.2"
+            "CHIA_BRANCH=2.1.2"
             "BLADEBIT_BRANCH=master"
             "PLOTMAN_BRANCH=compress"
           tags: |

--- a/.github/workflows/main-chia.yaml
+++ b/.github/workflows/main-chia.yaml
@@ -44,7 +44,7 @@ jobs:
           build-args: |
             "UBUNTU_VER=jammy"
             "MACHINARIS_STREAM=latest"
-            "CHIA_BRANCH=release/2.1.2"
+            "CHIA_BRANCH=2.1.2"
             "BLADEBIT_BRANCH=master"
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/machinaris:latest

--- a/.github/workflows/test-chia.yaml
+++ b/.github/workflows/test-chia.yaml
@@ -44,7 +44,7 @@ jobs:
             "UBUNTU_VER=jammy"
             "MACHINARIS_STREAM=test"
             "CHIADOG_BRANCH=dev"
-            "CHIA_BRANCH=release/2.1.2"
+            "CHIA_BRANCH=2.1.2"
             "PLOTMAN_BRANCH=development"
             "BLADEBIT_BRANCH=master"
           tags: |


### PR DESCRIPTION
<!-- Please develop and target PRs against the integration branch, not main. -->