### PR TITLE
Chia v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Updated
  - [Chia](https://github.com/Chia-Network/chia-blockchain/releases/tag/2.5.0) to v2.5.0 - misc improvements, see their release notes.
  - [Gigahorse](https://github.com/madMAx43v3r/chia-gigahorse/releases/tag/v2.4.4.giga36) to v2.4.4.giga36.  NOTE: Only for AMD64, so ARM64 uses previous version.
+### Notes
+ - Chia X.Y.0 releases have become quite buggy so I'm generally not bothering to release a full Machinaris X.Y.0 to match. 
 
 ## [2.4.4] - 2024-10-17
 ### Added

--- a/scripts/forks/chia_install.sh
+++ b/scripts/forks/chia_install.sh
@@ -27,10 +27,10 @@ else
     echo "Installing Chia CUDA binaries on ${arch_name}..."
     cd /tmp
     if [[ "${arch_name}" == "x86_64" ]]; then
-        curl -sLJO https://github.com/Chia-Network/chia-blockchain/releases/download/2.5.0-rc2/chia-blockchain-cli_2.5.0-rc2-1_amd64.deb
+        curl -sLJO https://github.com/Chia-Network/chia-blockchain/releases/download/2.5.0/chia-blockchain-cli_2.5.0-1_amd64.deb
         apt-get install ./chia-blockchain-cli*.deb
     else
-        curl -sLJO https://github.com/Chia-Network/chia-blockchain/releases/download/2.5.0-rc2/chia-blockchain-cli_2.5.0-rc2-1_arm64.deb
+        curl -sLJO https://github.com/Chia-Network/chia-blockchain/releases/download/2.5.0/chia-blockchain-cli_2.5.0-1_arm64.deb
         apt-get install ./chia-blockchain-cli*.deb
     fi
 

--- a/scripts/forks/chia_install.sh
+++ b/scripts/forks/chia_install.sh
@@ -27,10 +27,10 @@ else
     echo "Installing Chia CUDA binaries on ${arch_name}..."
     cd /tmp
     if [[ "${arch_name}" == "x86_64" ]]; then
-        curl -sLJO https://github.com/Chia-Network/chia-blockchain/releases/download/2.5.0-rc1/chia-blockchain-cli_2.5.0-rc1-1_amd64.deb
+        curl -sLJO https://github.com/Chia-Network/chia-blockchain/releases/download/2.5.0-rc2/chia-blockchain-cli_2.5.0-rc2-1_amd64.deb
         apt-get install ./chia-blockchain-cli*.deb
     else
-        curl -sLJO https://github.com/Chia-Network/chia-blockchain/releases/download/2.5.0-rc1/chia-blockchain-cli_2.5.0-rc1-1_arm64.deb
+        curl -sLJO https://github.com/Chia-Network/chia-blockchain/releases/download/2.5.0-rc2/chia-blockchain-cli_2.5.0-rc2-1_arm64.deb
         apt-get install ./chia-blockchain-cli*.deb
     fi
 


### PR DESCRIPTION
All Chia releases at .0 these days are suspect from a stability standpoint.